### PR TITLE
Brought back focused editor outline.

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -95,10 +95,6 @@ header h1 {
 	color: #333;
 }
 
-.ck-editor .ck-editor__editable_inline.ck-focused {
-	outline: none;
-}
-
 .ck-editor,
 .message {
 	position: relative;


### PR DESCRIPTION
Requires https://github.com/ckeditor/ckeditor5-theme-lark/pull/62.

Closes #24.

![dec-20-2016 13-42-36](https://cloud.githubusercontent.com/assets/1099479/21350892/3417ae38-c6ba-11e6-860a-7cf56d99859a.gif)
